### PR TITLE
Remove default dependency

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,3 @@
 name = jeans_economy
 description = Economy mod for Minetest-Servers
-depends = default
 optional_depends = atm


### PR DESCRIPTION
Removes "default" from the dependencies. This allows it to run on Mineclonia or LibreVoxle (Mineclone2) exile or any other game.

Closes #4 